### PR TITLE
Medical records, Growth record and Products  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ build/
 
 ### VS Code ###
 .vscode/
+kidic/src/main/resources/application.properties

--- a/kidic/README.md
+++ b/kidic/README.md
@@ -1,46 +1,291 @@
-# Kidic - Childcare Management System
+# Kidic Backend - API Documentation
 
-A comprehensive Spring Boot application for managing childcare facilities, children, classrooms, activities, and attendance.
+Spring Boot backend for Kidic. This document lists all APIs, request/response bodies, authentication, and error formats based on the current codebase.
 
-## Database Setup with XAMPP
+## Run
 
-### Prerequisites
-- XAMPP installed and running
-- Java 21 or higher
-- Maven or Gradle
+- Java 21, Gradle Wrapper
+- Build: `./gradlew build`
+- Run: `./gradlew bootRun`
+- Base URL: `http://localhost:8080`
 
-### Database Configuration
+## Authentication & Security
 
-1. **Start XAMPP Services**
-   - Start Apache and MySQL services in XAMPP Control Panel
+- JWT-based auth. Obtain a token via auth endpoints and send `Authorization: Bearer <token>`.
+- Public routes: `/api/auth/**`, `/api/test/**`, `/actuator/**`
+- All other routes require a valid JWT.
 
-2. **Create Database**
-   - Open phpMyAdmin (http://localhost/phpmyadmin)
-   - Create a new database named `kidic_db`
-   - Or run the SQL script: `src/main/resources/sql/init-database.sql`
+## Error Response Format
 
-3. **Database Connection**
-   - The application is configured to connect to MySQL on localhost:3306
-   - Default credentials: username=`root`, password=`` (empty)
-   - Database name: `kidic_db`
+On validation/business/unexpected errors the API returns the following shape:
 
-### Application Configuration
-
-The application is configured in `src/main/resources/application.properties`:
-
-```properties
-# Database Configuration for XAMPP MySQL
-spring.datasource.url=jdbc:mysql://localhost:3306/kidic_db?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
-spring.datasource.username=root
-spring.datasource.password=
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-
-# JPA/Hibernate Configuration
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
-spring.jpa.properties.hibernate.format_sql=true
+```json
+{
+  "timestamp": "2025-09-17T10:15:30",
+  "status": 400,
+  "error": "Validation Error | Bad Request | Internal Server Error",
+  "message": "Human readable details",
+  "path": "uri=/api/..."
+}
 ```
+
+## Auth APIs (`/api/auth`)
+
+### POST `/api/auth/signup/new-family`
+- Body:
+```json
+{
+  "name": "string",
+  "phone": "string",
+  "email": "user@example.com",
+  "gender": true,
+  "password": "string"
+}
+```
+- Response 200:
+```json
+{ "token": "<jwt>" }
+```
+
+### POST `/api/auth/signup/existing-family`
+- Body:
+```json
+{
+  "name": "string",
+  "phone": "string",
+  "email": "user@example.com",
+  "gender": true,
+  "password": "string",
+  "familyId": "uuid"
+}
+```
+- Response 200: `{ "token": "<jwt>" }`
+
+### POST `/api/auth/login`
+- Body:
+```json
+{ "email": "user@example.com", "password": "string" }
+```
+- Response 200: `{ "token": "<jwt>" }`
+
+## Child APIs (`/api/child`)
+
+Note: Controller uses `@RequestMapping(name = "api/child")`; this sets a name, not a path. If unreachable, change to `@RequestMapping("/api/child")`. Assuming path `/api/child` as intended.
+
+### POST `/api/child`
+- Headers: `Authorization: Bearer <token>`
+- Body:
+```json
+{
+  "name": "string (<=100)",
+  "gender": true,
+  "dateOfBirth": "YYYY-MM-DD",
+  "medicalNotes": "string (<=1000)"
+}
+```
+- Response 200:
+```json
+{
+  "name": "string",
+  "gender": true,
+  "dateOfBirth": "YYYY-MM-DD",
+  "medicalNotes": "string"
+}
+```
+
+## Product APIs (`/api/products`)
+
+### GET `/api/products`
+- Response 200: `Product[]`
+
+### POST `/api/products`
+- Body (JSON):
+```json
+{
+  "name": "string",
+  "link": "string",
+  "description": "string",
+  "imageType": "IMAGE_1|IMAGE_2|IMAGE_3|IMAGE_4|IMAGE_5|CUSTOM",
+  "category": "TOYS|BOOKS|CLOTHING|FOOD|MEDICAL|EDUCATIONAL|ENTERTAINMENT|OTHER"
+}
+```
+- Response 201: `Product`
+
+### PUT `/api/products/{productId}`
+- Body: same as POST
+- Response 200: `Product`
+
+### DELETE `/api/products/{productId}`
+- Response 204
+
+### POST `/api/products/{productId}/image`
+- Consumes: `multipart/form-data`
+- Fields: `file` (binary)
+- Response 200: `Product` (with updated image metadata)
+  - 400 on invalid upload, 404 if product not found
+
+### GET `/api/products/{productId}`
+- Response 200: `Product`; 404 if not found
+
+### GET `/api/products/{productId}/image`
+- Response 200: binary content with headers `Content-Type`, `Content-Disposition`, `Content-Length`
+- 404 if image missing or product not found
+
+### DELETE `/api/products/{productId}/image`
+- Response 200: `Product`; 404 if not found
+
+#### Product schema
+```json
+{
+  "id": 1,
+  "name": "string",
+  "link": "string",
+  "description": "string",
+  "imageType": "IMAGE_1|IMAGE_2|IMAGE_3|IMAGE_4|IMAGE_5|CUSTOM",
+  "imageName": "string",
+  "imageContent": "<bytes omitted>",
+  "imageSize": 123,
+  "imageContentType": "image/png",
+  "category": "TOYS|BOOKS|CLOTHING|FOOD|MEDICAL|EDUCATIONAL|ENTERTAINMENT|OTHER"
+}
+```
+
+## Growth Record APIs (`/api/growth-records`)
+
+Enums:
+- `GrowthType`: `EMOTIONAL|PHYSICAL|COGNITION`
+- `StatusType`: `ACHIEVED|NOT_ACHIEVED`
+
+### GET `/api/growth-records/children/{childId}`
+- Response 200: `GrowthRecord[]`
+
+### POST `/api/growth-records/children/{childId}`
+- Consumes: `application/x-www-form-urlencoded` or `multipart/form-data`
+- Fields:
+  - `additionalInfo` (optional string)
+  - `dateOfRecord` (required `YYYY-MM-DD`)
+  - `height` (optional number)
+  - `weight` (optional number)
+  - `type` (required enum)
+  - `status` (required enum)
+- Response 201: `GrowthRecord`
+
+### PUT `/api/growth-records/children/{childId}/{recordId}`
+- Consumes: form-data or urlencoded
+- Fields: same as POST but all optional
+- Response 200: `GrowthRecord`
+
+### DELETE `/api/growth-records/children/{childId}/{recordId}`
+- Response 204
+
+#### GrowthRecord schema
+```json
+{
+  "id": 1,
+  "additionalInfo": "string",
+  "dateOfRecord": "YYYY-MM-DD",
+  "height": 100.0,
+  "weight": 15.0,
+  "type": "EMOTIONAL|PHYSICAL|COGNITION",
+  "status": "ACHIEVED|NOT_ACHIEVED",
+  "child": { "id": 1, "name": "..." }
+}
+```
+
+## Medical Record APIs (`/api/medical-records`)
+
+Enums:
+- `MedicalRecordType`: `VACCINATION|CHECKUP|ILLNESS|INJURY|ALLERGY|MEDICATION|OTHER`
+- `FileType`: `PDF|IMAGE|DOCUMENT|VIDEO|AUDIO|OTHER`
+- `StatusType`: `ACTIVE|ARCHIVED|PENDING|COMPLETED|CANCELLED`
+
+### POST `/api/medical-records/children/{childId}`
+- Headers: `Authorization: Bearer <token>`
+- Body (JSON):
+```json
+{
+  "type": "MedicalRecordType",
+  "dateOfRecord": "YYYY-MM-DD",
+  "description": "string",
+  "file": "FileType",
+  "status": "StatusType"
+}
+```
+- Response 201: `MedicalRecordResponseDTO`
+
+### GET `/api/medical-records/children/{childId}`
+- Headers: `Authorization: Bearer <token>`
+- Response 200: `MedicalRecordResponseDTO[]`
+
+### GET `/api/medical-records/children/{childId}/{recordId}`
+- Headers: `Authorization: Bearer <token>`
+- Response 200: `MedicalRecordResponseDTO`
+
+### PUT `/api/medical-records/children/{childId}/{recordId}`
+- Headers: `Authorization: Bearer <token>`
+- Body: same as POST
+- Response 200: `MedicalRecordResponseDTO`
+
+### DELETE `/api/medical-records/children/{childId}/{recordId}`
+- Headers: `Authorization: Bearer <token>`
+- Response 204
+
+### POST `/api/medical-records/children/{childId}/with-file`
+- Headers: `Authorization: Bearer <token>`
+- Consumes: `multipart/form-data`
+- Fields:
+  - `type` (required, enum name)
+  - `dateOfRecord` (required, `YYYY-MM-DD`)
+  - `description` (optional)
+  - `status` (optional, enum name)
+  - `file` (optional, binary)
+- Response 201: `MedicalRecordResponseDTO`
+
+### PUT `/api/medical-records/children/{childId}/{recordId}/with-file`
+- Headers: `Authorization: Bearer <token>`
+- Consumes: `multipart/form-data`
+- Fields: same as POST with-file
+- Response 200: `MedicalRecordResponseDTO`
+
+### GET `/api/medical-records/children/{childId}/{recordId}/file`
+- Headers: `Authorization: Bearer <token>`
+- Response 200: binary download with content headers; 404 if missing
+
+#### MedicalRecordResponseDTO schema
+```json
+{
+  "id": 1,
+  "type": "MedicalRecordType",
+  "dateOfRecord": "YYYY-MM-DD",
+  "description": "string",
+  "fileType": "FileType",
+  "fileName": "string",
+  "fileContent": "<bytes omitted>",
+  "fileSize": 123,
+  "fileContentType": "application/pdf",
+  "status": "StatusType",
+  "childId": 1,
+  "childName": "string"
+}
+```
+
+## Test APIs (`/api/test`)
+
+All public.
+
+- GET `/api/test/database` → "Database connection successful!..." or 500
+- GET `/api/test/parents` → `Parent[]`
+- GET `/api/test/families` → `Family[]`
+- GET `/api/test/children` → `Child[]`
+- POST `/api/test/parents` → create `Parent`
+- POST `/api/test/init-data` → trigger `DataInitializer`
+- POST `/api/test/clear-data` → clear all
+- POST `/api/test/test-parent` → create a test parent
+
+## Notes & Gotchas
+
+- Child controller mapping likely should be `@RequestMapping("/api/child")` to expose the endpoint. If left as-is, the POST may not be reachable.
+- Some endpoints return entity models directly (e.g., `Product`, `GrowthRecord`) which include nested relations. Consider DTOs if you need to control exposure.
 
 ## Running the Application
 

--- a/kidic/environment.properties
+++ b/kidic/environment.properties
@@ -1,0 +1,14 @@
+# Database Configuration
+DB_HOST=localhost
+DB_PORT=3306
+DB_NAME=kidic_db
+DB_USER=root
+DB_PASS=your_password_here
+
+# JWT Configuration
+JWT_SECRET=JWTSecretKeyForMeatHomeAppSecureEnoughForHS256Algorithm
+JWT_EXPIRATION_MS=3600000
+JWT_EXPIRATION_MS_LONG=604800000
+
+# Server Configuration (optional)
+SERVER_PORT=8080

--- a/kidic/postman/Kidic.postman_collection.json
+++ b/kidic/postman/Kidic.postman_collection.json
@@ -1,0 +1,226 @@
+{
+    "info": {
+        "name": "Kidic API",
+        "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+        "_postman_id": "a4d2b9b0-0000-4000-8000-000000000001"
+    },
+    "item": [{
+            "name": "Test",
+            "item": [{
+                    "name": "DB Status",
+                    "request": {
+                        "method": "GET",
+                        "url": "{{baseUrl}}/api/test/database"
+                    }
+                },
+                {
+                    "name": "Init Data",
+                    "request": {
+                        "method": "POST",
+                        "url": "{{baseUrl}}/api/test/init-data"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Products",
+            "item": [{
+                    "name": "List Products",
+                    "request": {
+                        "method": "GET",
+                        "url": "{{baseUrl}}/api/products"
+                    }
+                },
+                {
+                    "name": "Create Product",
+                    "request": {
+                        "method": "POST",
+                        "header": [
+                            { "key": "Content-Type", "value": "application/json" }
+                        ],
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n  \"name\": \"Toy A\",\n  \"link\": \"https://example.com\",\n  \"description\": \"Nice toy\",\n  \"imageType\": \"IMAGE_1\",\n  \"category\": \"TOYS\"\n}"
+                        },
+                        "url": "{{baseUrl}}/api/products"
+                    }
+                },
+                {
+                    "name": "Get Product",
+                    "request": {
+                        "method": "GET",
+                        "url": "{{baseUrl}}/api/products/{{productId}}"
+                    }
+                },
+                {
+                    "name": "Update Product",
+                    "request": {
+                        "method": "PUT",
+                        "header": [
+                            { "key": "Content-Type", "value": "application/json" }
+                        ],
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n  \"name\": \"Toy A Updated\",\n  \"link\": \"https://example.com/a\",\n  \"description\": \"Updated\",\n  \"imageType\": \"IMAGE_2\",\n  \"category\": \"EDUCATIONAL\"\n}"
+                        },
+                        "url": "{{baseUrl}}/api/products/{{productId}}"
+                    }
+                },
+                {
+                    "name": "Delete Product",
+                    "request": {
+                        "method": "DELETE",
+                        "url": "{{baseUrl}}/api/products/{{productId}}"
+                    }
+                },
+                {
+                    "name": "Upload Product Image",
+                    "request": {
+                        "method": "POST",
+                        "header": [
+                            { "key": "Content-Type", "value": "multipart/form-data" }
+                        ],
+                        "body": {
+                            "mode": "formdata",
+                            "formdata": [
+                                { "key": "file", "type": "file", "src": [] }
+                            ]
+                        },
+                        "url": "{{baseUrl}}/api/products/{{productId}}/image"
+                    }
+                },
+                {
+                    "name": "Get Product Image",
+                    "request": {
+                        "method": "GET",
+                        "url": "{{baseUrl}}/api/products/{{productId}}/image"
+                    }
+                },
+                {
+                    "name": "Delete Product Image",
+                    "request": {
+                        "method": "DELETE",
+                        "url": "{{baseUrl}}/api/products/{{productId}}/image"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Medical Records",
+            "item": [{
+                    "name": "Add Medical Record (JSON)",
+                    "request": {
+                        "method": "POST",
+                        "header": [{ "key": "Content-Type", "value": "application/json" }],
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n  \"type\": \"CHECKUP\",\n  \"dateOfRecord\": \"2025-01-01\",\n  \"description\": \"Routine\",\n  \"status\": \"ACTIVE\"\n}"
+                        },
+                        "url": "{{baseUrl}}/api/medical-records/children/{{childId}}"
+                    }
+                },
+                {
+                    "name": "Add Medical Record With File",
+                    "request": {
+                        "method": "POST",
+                        "header": [{ "key": "Content-Type", "value": "multipart/form-data" }],
+                        "body": {
+                            "mode": "formdata",
+                            "formdata": [
+                                { "key": "type", "value": "CHECKUP", "type": "text" },
+                                { "key": "dateOfRecord", "value": "2025-01-01", "type": "text" },
+                                { "key": "description", "value": "Routine", "type": "text" },
+                                { "key": "status", "value": "ACTIVE", "type": "text" },
+                                { "key": "file", "type": "file", "src": [] }
+                            ]
+                        },
+                        "url": "{{baseUrl}}/api/medical-records/children/{{childId}}/with-file"
+                    }
+                },
+                {
+                    "name": "Download Medical Record File",
+                    "request": {
+                        "method": "GET",
+                        "url": "{{baseUrl}}/api/medical-records/children/{{childId}}/{{recordId}}/file"
+                    }
+                },
+                {
+                    "name": "Upload/Replace File (by ID)",
+                    "request": {
+                        "method": "POST",
+                        "header": [{ "key": "Content-Type", "value": "multipart/form-data" }],
+                        "body": {
+                            "mode": "formdata",
+                            "formdata": [{ "key": "file", "type": "file", "src": [] }]
+                        },
+                        "url": "{{baseUrl}}/api/medical-records/{{recordId}}/file"
+                    }
+                },
+                {
+                    "name": "Delete File (by ID)",
+                    "request": {
+                        "method": "DELETE",
+                        "url": "{{baseUrl}}/api/medical-records/{{recordId}}/file"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Growth Records",
+            "item": [{
+                    "name": "List for Child",
+                    "request": { "method": "GET", "url": "{{baseUrl}}/api/growth-records/children/{{childId}}" }
+                },
+                {
+                    "name": "Add for Child",
+                    "request": {
+                        "method": "POST",
+                        "header": [{ "key": "Content-Type", "value": "application/x-www-form-urlencoded" }],
+                        "body": {
+                            "mode": "urlencoded",
+                            "urlencoded": [
+                                { "key": "additionalInfo", "value": "Good progress" },
+                                { "key": "dateOfRecord", "value": "2025-01-02" },
+                                { "key": "height", "value": "100" },
+                                { "key": "weight", "value": "15" },
+                                { "key": "type", "value": "PHYSICAL" },
+                                { "key": "status", "value": "ACHIEVED" }
+                            ]
+                        },
+                        "url": "{{baseUrl}}/api/growth-records/children/{{childId}}"
+                    }
+                },
+                {
+                    "name": "Edit for Child",
+                    "request": {
+                        "method": "PUT",
+                        "header": [{ "key": "Content-Type", "value": "application/x-www-form-urlencoded" }],
+                        "body": {
+                            "mode": "urlencoded",
+                            "urlencoded": [
+                                { "key": "additionalInfo", "value": "Updated info" },
+                                { "key": "dateOfRecord", "value": "2025-01-03" },
+                                { "key": "height", "value": "101" },
+                                { "key": "weight", "value": "15.2" },
+                                { "key": "type", "value": "PHYSICAL" },
+                                { "key": "status", "value": "ACHIEVED" }
+                            ]
+                        },
+                        "url": "{{baseUrl}}/api/growth-records/children/{{childId}}/{{growthRecordId}}"
+                    }
+                },
+                {
+                    "name": "Delete for Child",
+                    "request": { "method": "DELETE", "url": "{{baseUrl}}/api/growth-records/children/{{childId}}/{{growthRecordId}}" }
+                }
+            ]
+        }
+    ],
+    "variable": [
+        { "key": "baseUrl", "value": "http://localhost:8080" },
+        { "key": "productId", "value": "1" },
+        { "key": "childId", "value": "1" },
+        { "key": "recordId", "value": "1" },
+        { "key": "growthRecordId", "value": "1" }
+    ]
+}

--- a/kidic/src/main/java/com/example/kidic/config/DataInitializer.java
+++ b/kidic/src/main/java/com/example/kidic/config/DataInitializer.java
@@ -64,37 +64,29 @@ public class DataInitializer implements CommandLineRunner {
     private void initializeData() {
         try {
 
-            // Create Families
-            Family family1 = new Family();
-            family1.setId(UUID.fromString("550e8400-e29b-41d4-a716-446655440001"));
-
-            Family family2 = new Family();
-            family2.setId(UUID.fromString("550e8400-e29b-41d4-a716-446655440002"));
-
-            familyRepository.saveAll(Arrays.asList(family1, family2));
+            // Create Families (let JPA generate IDs to avoid optimistic locking issues)
+            Family family1 = familyRepository.save(new Family());
+            Family family2 = familyRepository.save(new Family());
 
             System.out.println("👨‍👩‍👧‍👦 Creating parents...");
             // Create Parents
             Parent parent1 = new Parent("John Smith", "1234567890", "john.smith@email.com", true,
                     "$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iAt6Z5EHsM8lE9lBOsl7iKTVEFDi");
-            parent1.setProfilePicture(Parent.ProfilePictureType.DEFAULT);
+            parent1.setProfilePictureType(Parent.ProfilePictureType.DEFAULT);
             parent1.setFamily(family1);
 
             Parent parent2 = new Parent("Jane Smith", "1234567891", "jane.smith@email.com", false,
                     "$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iAt6Z5EHsM8lE9lBOsl7iKTVEFDi");
-            parent2.setProfilePicture(Parent.ProfilePictureType.AVATAR_1);
+            parent2.setProfilePictureType(Parent.ProfilePictureType.AVATAR_1);
             parent2.setFamily(family1);
 
             Parent parent3 = new Parent("Mike Johnson", "1234567892", "mike.johnson@email.com", true,
                     "$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iAt6Z5EHsM8lE9lBOsl7iKTVEFDi");
-            parent3.setProfilePicture(Parent.ProfilePictureType.CUSTOM);
+            parent3.setProfilePictureType(Parent.ProfilePictureType.CUSTOM);
             parent3.setFamily(family2);
+            // Persist parents separately (owning side), no need to resave families
+            parentRepository.saveAll(Arrays.asList(parent1, parent2, parent3));
             System.out.println("✅ Parents created successfully");
-
-        // Add parents to families
-        family1.getParents().addAll(Arrays.asList(parent1, parent2));
-        family2.getParents().add(parent3);
-        familyRepository.saveAll(Arrays.asList(family1, family2));
 
         // Create Children
         Child child1 = new Child("Emma Smith", false, LocalDate.of(2020, 5, 15), null, family1);

--- a/kidic/src/main/java/com/example/kidic/config/SecurityConfiguration.java
+++ b/kidic/src/main/java/com/example/kidic/config/SecurityConfiguration.java
@@ -25,7 +25,7 @@ public class SecurityConfiguration {
 
                 // Authorization rules
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("api/auth/**").permitAll()   // example: public endpoints
+                        .requestMatchers("/api/auth/**", "/api/test/**", "/actuator/**").permitAll()
                         .anyRequest().authenticated()
                 )
 

--- a/kidic/src/main/java/com/example/kidic/controller/GrowthRecordController.java
+++ b/kidic/src/main/java/com/example/kidic/controller/GrowthRecordController.java
@@ -1,0 +1,77 @@
+package com.example.kidic.controller;
+
+import com.example.kidic.entity.GrowthRecord;
+import com.example.kidic.service.GrowthRecordService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/growth-records")
+@CrossOrigin(origins = "*")
+public class GrowthRecordController {
+
+    @Autowired
+    private GrowthRecordService growthRecordService;
+
+    @GetMapping("/children/{childId}")
+    public ResponseEntity<List<GrowthRecord>> listForChild(@PathVariable Long childId) {
+        return ResponseEntity.ok(growthRecordService.listForChild(childId));
+    }
+
+    @PostMapping("/children/{childId}")
+    public ResponseEntity<GrowthRecord> addForChild(
+            @PathVariable Long childId,
+            @RequestParam(value = "additionalInfo", required = false) String additionalInfo,
+            @RequestParam("dateOfRecord") String dateOfRecord,
+            @RequestParam(value = "height", required = false) Double height,
+            @RequestParam(value = "weight", required = false) Double weight,
+            @RequestParam("type") GrowthRecord.GrowthType type,
+            @RequestParam("status") GrowthRecord.StatusType status) {
+        GrowthRecord created = growthRecordService.addForChild(
+                childId,
+                additionalInfo,
+                LocalDate.parse(dateOfRecord),
+                height,
+                weight,
+                type,
+                status
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @PutMapping("/children/{childId}/{recordId}")
+    public ResponseEntity<GrowthRecord> editForChild(
+            @PathVariable Long childId,
+            @PathVariable Long recordId,
+            @RequestParam(value = "additionalInfo", required = false) String additionalInfo,
+            @RequestParam(value = "dateOfRecord", required = false) String dateOfRecord,
+            @RequestParam(value = "height", required = false) Double height,
+            @RequestParam(value = "weight", required = false) Double weight,
+            @RequestParam(value = "type", required = false) GrowthRecord.GrowthType type,
+            @RequestParam(value = "status", required = false) GrowthRecord.StatusType status) {
+        GrowthRecord updated = growthRecordService.editForChild(
+                childId,
+                recordId,
+                additionalInfo,
+                dateOfRecord != null ? LocalDate.parse(dateOfRecord) : null,
+                height,
+                weight,
+                type,
+                status
+        );
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/children/{childId}/{recordId}")
+    public ResponseEntity<Void> deleteForChild(@PathVariable Long childId, @PathVariable Long recordId) {
+        growthRecordService.deleteForChild(childId, recordId);
+        return ResponseEntity.noContent().build();
+    }
+}
+
+

--- a/kidic/src/main/java/com/example/kidic/controller/MedicalRecordController.java
+++ b/kidic/src/main/java/com/example/kidic/controller/MedicalRecordController.java
@@ -1,0 +1,203 @@
+package com.example.kidic.controller;
+
+import com.example.kidic.dto.MedicalRecordRequestDTO;
+import com.example.kidic.dto.MedicalRecordResponseDTO;
+import com.example.kidic.dto.MedicalRecordWithFileRequestDTO;
+import com.example.kidic.service.MedicalRecordService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/medical-records")
+@CrossOrigin(origins = "*")
+public class MedicalRecordController {
+    
+    @Autowired
+    private MedicalRecordService medicalRecordService;
+    
+    /**
+     * Add a new medical record for a specific child
+     * POST /api/medical-records/children/{childId}
+     */
+    @PostMapping("/children/{childId}")
+    public ResponseEntity<MedicalRecordResponseDTO> addMedicalRecord(
+            @PathVariable Long childId,
+            @Valid @RequestBody MedicalRecordRequestDTO request,
+            HttpServletRequest httpRequest) {
+        
+        String token = extractTokenFromRequest(httpRequest);
+        MedicalRecordResponseDTO response = medicalRecordService.addMedicalRecord(childId, request, token);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+    
+    /**
+     * Get all medical records for a specific child
+     * GET /api/medical-records/children/{childId}
+     */
+    @GetMapping("/children/{childId}")
+    public ResponseEntity<List<MedicalRecordResponseDTO>> getMedicalRecordsForChild(
+            @PathVariable Long childId,
+            HttpServletRequest httpRequest) {
+        
+        String token = extractTokenFromRequest(httpRequest);
+        List<MedicalRecordResponseDTO> response = medicalRecordService.getMedicalRecordsForChild(childId, token);
+        return ResponseEntity.ok(response);
+    }
+    
+    /**
+     * Get a specific medical record
+     * GET /api/medical-records/children/{childId}/{recordId}
+     */
+    @GetMapping("/children/{childId}/{recordId}")
+    public ResponseEntity<MedicalRecordResponseDTO> getMedicalRecord(
+            @PathVariable Long childId,
+            @PathVariable Long recordId,
+            HttpServletRequest httpRequest) {
+        
+        String token = extractTokenFromRequest(httpRequest);
+        MedicalRecordResponseDTO response = medicalRecordService.getMedicalRecord(childId, recordId, token);
+        return ResponseEntity.ok(response);
+    }
+    
+    /**
+     * Edit an existing medical record
+     * PUT /api/medical-records/children/{childId}/{recordId}
+     */
+    @PutMapping("/children/{childId}/{recordId}")
+    public ResponseEntity<MedicalRecordResponseDTO> editMedicalRecord(
+            @PathVariable Long childId,
+            @PathVariable Long recordId,
+            @Valid @RequestBody MedicalRecordRequestDTO request,
+            HttpServletRequest httpRequest) {
+        
+        String token = extractTokenFromRequest(httpRequest);
+        MedicalRecordResponseDTO response = medicalRecordService.editMedicalRecord(childId, recordId, request, token);
+        return ResponseEntity.ok(response);
+    }
+    
+    /**
+     * Delete a medical record
+     * DELETE /api/medical-records/children/{childId}/{recordId}
+     */
+    @DeleteMapping("/children/{childId}/{recordId}")
+    public ResponseEntity<Void> deleteMedicalRecord(
+            @PathVariable Long childId,
+            @PathVariable Long recordId,
+            HttpServletRequest httpRequest) {
+        
+        String token = extractTokenFromRequest(httpRequest);
+        medicalRecordService.deleteMedicalRecord(childId, recordId, token);
+        return ResponseEntity.noContent().build();
+    }
+    
+    /**
+     * Add a new medical record with file upload for a specific child
+     * POST /api/medical-records/children/{childId}/with-file
+     */
+    @PostMapping(value = "/children/{childId}/with-file", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<MedicalRecordResponseDTO> addMedicalRecordWithFile(
+            @PathVariable Long childId,
+            @RequestParam("type") String type,
+            @RequestParam("dateOfRecord") String dateOfRecord,
+            @RequestParam(value = "description", required = false) String description,
+            @RequestParam(value = "status", required = false) String status,
+            @RequestParam(value = "file", required = false) MultipartFile file,
+            HttpServletRequest httpRequest) {
+        
+        String token = extractTokenFromRequest(httpRequest);
+        
+        try {
+            MedicalRecordWithFileRequestDTO request = new MedicalRecordWithFileRequestDTO();
+            request.setType(com.example.kidic.entity.MedicalRecord.MedicalRecordType.valueOf(type));
+            request.setDateOfRecord(java.time.LocalDate.parse(dateOfRecord));
+            request.setDescription(description);
+            if (status != null) {
+                request.setStatus(com.example.kidic.entity.MedicalRecord.StatusType.valueOf(status));
+            }
+            request.setFile(file);
+            
+            MedicalRecordResponseDTO response = medicalRecordService.addMedicalRecordWithFile(childId, request, token);
+            return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to process file upload: " + e.getMessage());
+        }
+    }
+    
+    /**
+     * Edit an existing medical record with optional file upload
+     * PUT /api/medical-records/children/{childId}/{recordId}/with-file
+     */
+    @PutMapping(value = "/children/{childId}/{recordId}/with-file", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<MedicalRecordResponseDTO> editMedicalRecordWithFile(
+            @PathVariable Long childId,
+            @PathVariable Long recordId,
+            @RequestParam("type") String type,
+            @RequestParam("dateOfRecord") String dateOfRecord,
+            @RequestParam(value = "description", required = false) String description,
+            @RequestParam(value = "status", required = false) String status,
+            @RequestParam(value = "file", required = false) MultipartFile file,
+            HttpServletRequest httpRequest) {
+        
+        String token = extractTokenFromRequest(httpRequest);
+        
+        try {
+            MedicalRecordWithFileRequestDTO request = new MedicalRecordWithFileRequestDTO();
+            request.setType(com.example.kidic.entity.MedicalRecord.MedicalRecordType.valueOf(type));
+            request.setDateOfRecord(java.time.LocalDate.parse(dateOfRecord));
+            request.setDescription(description);
+            if (status != null) {
+                request.setStatus(com.example.kidic.entity.MedicalRecord.StatusType.valueOf(status));
+            }
+            request.setFile(file);
+            
+            MedicalRecordResponseDTO response = medicalRecordService.editMedicalRecordWithFile(childId, recordId, request, token);
+            return ResponseEntity.ok(response);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to process file upload: " + e.getMessage());
+        }
+    }
+    
+    /**
+     * Download a file associated with a medical record
+     * GET /api/medical-records/children/{childId}/{recordId}/file
+     */
+    @GetMapping("/children/{childId}/{recordId}/file")
+    public ResponseEntity<byte[]> downloadFile(
+            @PathVariable Long childId,
+            @PathVariable Long recordId,
+            HttpServletRequest httpRequest) {
+        
+        String token = extractTokenFromRequest(httpRequest);
+        MedicalRecordResponseDTO record = medicalRecordService.getMedicalRecord(childId, recordId, token);
+        
+        if (record.getFileContent() == null || record.getFileContent().length == 0) {
+            return ResponseEntity.notFound().build();
+        }
+        
+        return ResponseEntity.ok()
+                .contentType(org.springframework.http.MediaType.parseMediaType(record.getFileContentType()))
+                .header("Content-Disposition", "attachment; filename=\"" + record.getFileName() + "\"")
+                .header("Content-Length", String.valueOf(record.getFileSize()))
+                .body(record.getFileContent());
+    }
+    
+    /**
+     * Extract JWT token from the Authorization header
+     */
+    private String extractTokenFromRequest(HttpServletRequest request) {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            return authHeader.substring(7);
+        }
+        throw new IllegalArgumentException("Authorization token is required");
+    }
+}

--- a/kidic/src/main/java/com/example/kidic/controller/ProductController.java
+++ b/kidic/src/main/java/com/example/kidic/controller/ProductController.java
@@ -1,0 +1,127 @@
+package com.example.kidic.controller;
+
+import com.example.kidic.entity.Product;
+import com.example.kidic.service.ProductService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/products")
+@CrossOrigin(origins = "*")
+public class ProductController {
+    @GetMapping
+    public ResponseEntity<List<Product>> listProducts() {
+        return ResponseEntity.ok(productService.listProducts());
+    }
+
+    @PostMapping
+    public ResponseEntity<Product> createProduct(@RequestBody Product request) {
+        Product created = productService.createProduct(
+                request.getName(),
+                request.getLink(),
+                request.getDescription(),
+                request.getImageType(),
+                request.getCategory()
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @PutMapping("/{productId}")
+    public ResponseEntity<Product> updateProduct(@PathVariable Long productId, @RequestBody Product request) {
+        Product updated = productService.updateProduct(
+                productId,
+                request.getName(),
+                request.getLink(),
+                request.getDescription(),
+                request.getImageType(),
+                request.getCategory()
+        );
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/{productId}")
+    public ResponseEntity<Void> deleteProduct(@PathVariable Long productId) {
+        productService.deleteProduct(productId);
+        return ResponseEntity.noContent().build();
+    }
+    
+    @Autowired
+    private ProductService productService;
+    
+    /**
+     * Upload image for a product
+     * POST /api/products/{productId}/image
+     */
+    @PostMapping(value = "/{productId}/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Product> uploadProductImage(
+            @PathVariable Long productId,
+            @RequestParam("file") MultipartFile file) {
+        
+        try {
+            Product updatedProduct = productService.uploadProductImage(productId, file);
+            return ResponseEntity.ok(updatedProduct);
+        } catch (IOException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        }
+    }
+    
+    /**
+     * Get product image
+     * GET /api/products/{productId}/image
+     */
+    @GetMapping("/{productId}/image")
+    public ResponseEntity<byte[]> getProductImage(@PathVariable Long productId) {
+        try {
+            Product product = productService.getProduct(productId);
+            
+            if (product.getImageContent() == null || product.getImageContent().length == 0) {
+                return ResponseEntity.notFound().build();
+            }
+            
+            return ResponseEntity.ok()
+                    .contentType(org.springframework.http.MediaType.parseMediaType(product.getImageContentType()))
+                    .header("Content-Disposition", "inline; filename=\"" + product.getImageName() + "\"")
+                    .header("Content-Length", String.valueOf(product.getImageSize()))
+                    .body(product.getImageContent());
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+    
+    /**
+     * Delete product image
+     * DELETE /api/products/{productId}/image
+     */
+    @DeleteMapping("/{productId}/image")
+    public ResponseEntity<Product> deleteProductImage(@PathVariable Long productId) {
+        try {
+            Product updatedProduct = productService.deleteProductImage(productId);
+            return ResponseEntity.ok(updatedProduct);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+    
+    /**
+     * Get product information
+     * GET /api/products/{productId}
+     */
+    @GetMapping("/{productId}")
+    public ResponseEntity<Product> getProduct(@PathVariable Long productId) {
+        try {
+            Product product = productService.getProduct(productId);
+            return ResponseEntity.ok(product);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+}

--- a/kidic/src/main/java/com/example/kidic/controller/TestController.java
+++ b/kidic/src/main/java/com/example/kidic/controller/TestController.java
@@ -110,7 +110,7 @@ public class TestController {
     public ResponseEntity<String> createTestParent() {
         try {
             Parent testParent = new Parent("Test Parent", "1234567890", "test@email.com", true, "password123");
-            testParent.setProfilePicture(Parent.ProfilePictureType.DEFAULT);
+            testParent.setProfilePictureType(Parent.ProfilePictureType.DEFAULT);
             parentRepository.save(testParent);
             return ResponseEntity.ok("Test parent created successfully! ID: " + testParent.getId());
         } catch (Exception e) {

--- a/kidic/src/main/java/com/example/kidic/dto/MedicalRecordRequestDTO.java
+++ b/kidic/src/main/java/com/example/kidic/dto/MedicalRecordRequestDTO.java
@@ -1,0 +1,76 @@
+package com.example.kidic.dto;
+
+import com.example.kidic.entity.MedicalRecord;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+
+public class MedicalRecordRequestDTO {
+    
+    @NotNull(message = "Medical record type is required")
+    private MedicalRecord.MedicalRecordType type;
+    
+    @NotNull(message = "Date of record is required")
+    private LocalDate dateOfRecord;
+    
+    @Size(max = 1000, message = "Description must not exceed 1000 characters")
+    private String description;
+    
+    private MedicalRecord.FileType file;
+    
+    private MedicalRecord.StatusType status;
+    
+    // Constructors
+    public MedicalRecordRequestDTO() {}
+    
+    public MedicalRecordRequestDTO(MedicalRecord.MedicalRecordType type, LocalDate dateOfRecord, 
+                                  String description, MedicalRecord.FileType file, 
+                                  MedicalRecord.StatusType status) {
+        this.type = type;
+        this.dateOfRecord = dateOfRecord;
+        this.description = description;
+        this.file = file;
+        this.status = status;
+    }
+    
+    // Getters and Setters
+    public MedicalRecord.MedicalRecordType getType() {
+        return type;
+    }
+    
+    public void setType(MedicalRecord.MedicalRecordType type) {
+        this.type = type;
+    }
+    
+    public LocalDate getDateOfRecord() {
+        return dateOfRecord;
+    }
+    
+    public void setDateOfRecord(LocalDate dateOfRecord) {
+        this.dateOfRecord = dateOfRecord;
+    }
+    
+    public String getDescription() {
+        return description;
+    }
+    
+    public void setDescription(String description) {
+        this.description = description;
+    }
+    
+    public MedicalRecord.FileType getFile() {
+        return file;
+    }
+    
+    public void setFile(MedicalRecord.FileType file) {
+        this.file = file;
+    }
+    
+    public MedicalRecord.StatusType getStatus() {
+        return status;
+    }
+    
+    public void setStatus(MedicalRecord.StatusType status) {
+        this.status = status;
+    }
+}

--- a/kidic/src/main/java/com/example/kidic/dto/MedicalRecordResponseDTO.java
+++ b/kidic/src/main/java/com/example/kidic/dto/MedicalRecordResponseDTO.java
@@ -1,0 +1,44 @@
+package com.example.kidic.dto;
+
+import com.example.kidic.entity.MedicalRecord;
+import lombok.Builder;
+import lombok.Data;
+import java.time.LocalDate;
+
+@Data
+@Builder
+public class MedicalRecordResponseDTO {
+    
+    private Long id;
+    private MedicalRecord.MedicalRecordType type;
+    private LocalDate dateOfRecord;
+    private String description;
+    private MedicalRecord.FileType fileType;
+    private String fileName;
+    private byte[] fileContent;
+    private Long fileSize;
+    private String fileContentType;
+    private MedicalRecord.StatusType status;
+    private Long childId;
+    private String childName;
+    
+    public MedicalRecordResponseDTO() {}
+    
+    public MedicalRecordResponseDTO(Long id, MedicalRecord.MedicalRecordType type, LocalDate dateOfRecord,
+                                   String description, MedicalRecord.FileType fileType, String fileName,
+                                   byte[] fileContent, Long fileSize, String fileContentType,
+                                   MedicalRecord.StatusType status, Long childId, String childName) {
+        this.id = id;
+        this.type = type;
+        this.dateOfRecord = dateOfRecord;
+        this.description = description;
+        this.fileType = fileType;
+        this.fileName = fileName;
+        this.fileContent = fileContent;
+        this.fileSize = fileSize;
+        this.fileContentType = fileContentType;
+        this.status = status;
+        this.childId = childId;
+        this.childName = childName;
+    }
+}

--- a/kidic/src/main/java/com/example/kidic/dto/MedicalRecordWithFileRequestDTO.java
+++ b/kidic/src/main/java/com/example/kidic/dto/MedicalRecordWithFileRequestDTO.java
@@ -1,0 +1,77 @@
+package com.example.kidic.dto;
+
+import com.example.kidic.entity.MedicalRecord;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+
+public class MedicalRecordWithFileRequestDTO {
+    
+    @NotNull(message = "Medical record type is required")
+    private MedicalRecord.MedicalRecordType type;
+    
+    @NotNull(message = "Date of record is required")
+    private LocalDate dateOfRecord;
+    
+    @Size(max = 1000, message = "Description must not exceed 1000 characters")
+    private String description;
+    
+    private MedicalRecord.StatusType status;
+    
+    private MultipartFile file;
+    
+    // Constructors
+    public MedicalRecordWithFileRequestDTO() {}
+    
+    public MedicalRecordWithFileRequestDTO(MedicalRecord.MedicalRecordType type, LocalDate dateOfRecord, 
+                                          String description, MedicalRecord.StatusType status, MultipartFile file) {
+        this.type = type;
+        this.dateOfRecord = dateOfRecord;
+        this.description = description;
+        this.status = status;
+        this.file = file;
+    }
+    
+    // Getters and Setters
+    public MedicalRecord.MedicalRecordType getType() {
+        return type;
+    }
+    
+    public void setType(MedicalRecord.MedicalRecordType type) {
+        this.type = type;
+    }
+    
+    public LocalDate getDateOfRecord() {
+        return dateOfRecord;
+    }
+    
+    public void setDateOfRecord(LocalDate dateOfRecord) {
+        this.dateOfRecord = dateOfRecord;
+    }
+    
+    public String getDescription() {
+        return description;
+    }
+    
+    public void setDescription(String description) {
+        this.description = description;
+    }
+    
+    public MedicalRecord.StatusType getStatus() {
+        return status;
+    }
+    
+    public void setStatus(MedicalRecord.StatusType status) {
+        this.status = status;
+    }
+    
+    public MultipartFile getFile() {
+        return file;
+    }
+    
+    public void setFile(MultipartFile file) {
+        this.file = file;
+    }
+}

--- a/kidic/src/main/java/com/example/kidic/entity/MedicalRecord.java
+++ b/kidic/src/main/java/com/example/kidic/entity/MedicalRecord.java
@@ -1,7 +1,6 @@
 package com.example.kidic.entity;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
@@ -25,7 +24,22 @@ public class MedicalRecord {
     private String description;
     
     @Enumerated(EnumType.STRING)
-    private FileType file;
+    @Column(name = "file_type")
+    private FileType fileType;
+    
+    @Size(max = 500)
+    @Column(name = "file_name")
+    private String fileName;
+    
+    @Column(name = "file_content", columnDefinition = "LONGBLOB")
+    private byte[] fileContent;
+    
+    @Column(name = "file_size")
+    private Long fileSize;
+    
+    @Size(max = 100)
+    @Column(name = "file_content_type")
+    private String fileContentType;
     
     @Enumerated(EnumType.STRING)
     private StatusType status;
@@ -38,11 +52,11 @@ public class MedicalRecord {
     public MedicalRecord() {}
     
     public MedicalRecord(MedicalRecordType type, LocalDate dateOfRecord, String description, 
-                        FileType file, StatusType status, Child child) {
+                        FileType fileType, StatusType status, Child child) {
         this.type = type;
         this.dateOfRecord = dateOfRecord;
         this.description = description;
-        this.file = file;
+        this.fileType = fileType;
         this.status = status;
         this.child = child;
     }
@@ -80,12 +94,44 @@ public class MedicalRecord {
         this.description = description;
     }
     
-    public FileType getFile() {
-        return file;
+    public FileType getFileType() {
+        return fileType;
     }
     
-    public void setFile(FileType file) {
-        this.file = file;
+    public void setFileType(FileType fileType) {
+        this.fileType = fileType;
+    }
+    
+    public String getFileName() {
+        return fileName;
+    }
+    
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+    
+    public byte[] getFileContent() {
+        return fileContent;
+    }
+    
+    public void setFileContent(byte[] fileContent) {
+        this.fileContent = fileContent;
+    }
+    
+    public Long getFileSize() {
+        return fileSize;
+    }
+    
+    public void setFileSize(Long fileSize) {
+        this.fileSize = fileSize;
+    }
+    
+    public String getFileContentType() {
+        return fileContentType;
+    }
+    
+    public void setFileContentType(String fileContentType) {
+        this.fileContentType = fileContentType;
     }
     
     public StatusType getStatus() {

--- a/kidic/src/main/java/com/example/kidic/entity/Parent.java
+++ b/kidic/src/main/java/com/example/kidic/entity/Parent.java
@@ -7,7 +7,6 @@ import jakarta.validation.constraints.Size;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -39,8 +38,22 @@ public class Parent implements UserDetails {
     private String password; // Hashed String
     
     @Enumerated(EnumType.STRING)
-    @Column(name = "profile_picture")
-    private ProfilePictureType profilePicture;
+    @Column(name = "profile_picture_type")
+    private ProfilePictureType profilePictureType;
+    
+    @Size(max = 500)
+    @Column(name = "profile_picture_name")
+    private String profilePictureName;
+    
+    @Column(name = "profile_picture_content", columnDefinition = "LONGBLOB")
+    private byte[] profilePictureContent;
+    
+    @Column(name = "profile_picture_size")
+    private Long profilePictureSize;
+    
+    @Size(max = 100)
+    @Column(name = "profile_picture_content_type")
+    private String profilePictureContentType;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "family_id", nullable = true)
@@ -108,12 +121,44 @@ public class Parent implements UserDetails {
         this.password = password;
     }
     
-    public ProfilePictureType getProfilePicture() {
-        return profilePicture;
+    public ProfilePictureType getProfilePictureType() {
+        return profilePictureType;
     }
     
-    public void setProfilePicture(ProfilePictureType profilePicture) {
-        this.profilePicture = profilePicture;
+    public void setProfilePictureType(ProfilePictureType profilePictureType) {
+        this.profilePictureType = profilePictureType;
+    }
+    
+    public String getProfilePictureName() {
+        return profilePictureName;
+    }
+    
+    public void setProfilePictureName(String profilePictureName) {
+        this.profilePictureName = profilePictureName;
+    }
+    
+    public byte[] getProfilePictureContent() {
+        return profilePictureContent;
+    }
+    
+    public void setProfilePictureContent(byte[] profilePictureContent) {
+        this.profilePictureContent = profilePictureContent;
+    }
+    
+    public Long getProfilePictureSize() {
+        return profilePictureSize;
+    }
+    
+    public void setProfilePictureSize(Long profilePictureSize) {
+        this.profilePictureSize = profilePictureSize;
+    }
+    
+    public String getProfilePictureContentType() {
+        return profilePictureContentType;
+    }
+    
+    public void setProfilePictureContentType(String profilePictureContentType) {
+        this.profilePictureContentType = profilePictureContentType;
     }
 
     public Family getFamily() {

--- a/kidic/src/main/java/com/example/kidic/entity/Product.java
+++ b/kidic/src/main/java/com/example/kidic/entity/Product.java
@@ -26,7 +26,22 @@ public class Product {
     private String description; // Note: keeping as "description" despite typo in ERD
     
     @Enumerated(EnumType.STRING)
-    private ImageType image;
+    @Column(name = "image_type")
+    private ImageType imageType;
+    
+    @Size(max = 500)
+    @Column(name = "image_name")
+    private String imageName;
+    
+    @Column(name = "image_content", columnDefinition = "LONGBLOB")
+    private byte[] imageContent;
+    
+    @Column(name = "image_size")
+    private Long imageSize;
+    
+    @Size(max = 100)
+    @Column(name = "image_content_type")
+    private String imageContentType;
     
     @Enumerated(EnumType.STRING)
     private CategoryType category;
@@ -37,11 +52,11 @@ public class Product {
     // Constructors
     public Product() {}
     
-    public Product(String name, String link, String description, ImageType image, CategoryType category) {
+    public Product(String name, String link, String description, ImageType imageType, CategoryType category) {
         this.name = name;
         this.link = link;
         this.description = description;
-        this.image = image;
+        this.imageType = imageType;
         this.category = category;
     }
     
@@ -78,12 +93,44 @@ public class Product {
         this.description = description;
     }
     
-    public ImageType getImage() {
-        return image;
+    public ImageType getImageType() {
+        return imageType;
     }
     
-    public void setImage(ImageType image) {
-        this.image = image;
+    public void setImageType(ImageType imageType) {
+        this.imageType = imageType;
+    }
+    
+    public String getImageName() {
+        return imageName;
+    }
+    
+    public void setImageName(String imageName) {
+        this.imageName = imageName;
+    }
+    
+    public byte[] getImageContent() {
+        return imageContent;
+    }
+    
+    public void setImageContent(byte[] imageContent) {
+        this.imageContent = imageContent;
+    }
+    
+    public Long getImageSize() {
+        return imageSize;
+    }
+    
+    public void setImageSize(Long imageSize) {
+        this.imageSize = imageSize;
+    }
+    
+    public String getImageContentType() {
+        return imageContentType;
+    }
+    
+    public void setImageContentType(String imageContentType) {
+        this.imageContentType = imageContentType;
     }
     
     public CategoryType getCategory() {

--- a/kidic/src/main/java/com/example/kidic/repository/ProductRepository.java
+++ b/kidic/src/main/java/com/example/kidic/repository/ProductRepository.java
@@ -17,8 +17,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Query("SELECT p FROM Product p WHERE p.category = :category")
     List<Product> findByCategory(@Param("category") Product.CategoryType category);
     
-    @Query("SELECT p FROM Product p WHERE p.image = :image")
-    List<Product> findByImage(@Param("image") Product.ImageType image);
+    @Query("SELECT p FROM Product p WHERE p.imageType = :imageType")
+    List<Product> findByImage(@Param("imageType") Product.ImageType image);
     
     @Query("SELECT p FROM Product p WHERE p.description LIKE %:description%")
     List<Product> findByDescriptionContaining(@Param("description") String description);

--- a/kidic/src/main/java/com/example/kidic/service/FileStorageService.java
+++ b/kidic/src/main/java/com/example/kidic/service/FileStorageService.java
@@ -1,0 +1,169 @@
+package com.example.kidic.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+public class FileStorageService {
+    
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+    
+    private static final String[] ALLOWED_EXTENSIONS = {
+        ".pdf", ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff",
+        ".doc", ".docx", ".txt", ".mp4", ".avi", ".mov", ".mp3", ".wav"
+    };
+    
+    private static final String[] ALLOWED_CONTENT_TYPES = {
+        "application/pdf",
+        "image/jpeg", "image/png", "image/gif", "image/bmp", "image/tiff",
+        "application/msword", "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "text/plain", "video/mp4", "video/avi", "video/quicktime",
+        "audio/mpeg", "audio/wav"
+    };
+    
+    /**
+     * Process uploaded file and return file information for database storage
+     */
+    public FileStorageResult processFileForDatabase(MultipartFile file) throws IOException {
+        if (file.isEmpty()) {
+            throw new IllegalArgumentException("File is empty");
+        }
+        
+        // Validate file size
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new IllegalArgumentException("File size exceeds maximum allowed size of " + (MAX_FILE_SIZE / 1024 / 1024) + "MB");
+        }
+        
+        // Validate file extension
+        String originalFileName = file.getOriginalFilename();
+        if (originalFileName == null || !isValidFileExtension(originalFileName)) {
+            throw new IllegalArgumentException("File type not allowed. Allowed types: PDF, Images, Documents, Videos, Audio");
+        }
+        
+        // Validate content type
+        String contentType = file.getContentType();
+        if (contentType == null || !isValidContentType(contentType)) {
+            throw new IllegalArgumentException("File content type not allowed");
+        }
+        
+        // Read file content into byte array
+        byte[] fileContent = file.getBytes();
+        
+        // Return file information for database storage
+        return new FileStorageResult(
+            originalFileName,
+            fileContent,
+            file.getSize(),
+            contentType,
+            getFileTypeFromContentType(contentType)
+        );
+    }
+    
+    /**
+     * Validate file for upload
+     */
+    public void validateFile(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new IllegalArgumentException("File is empty");
+        }
+        
+        // Validate file size
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new IllegalArgumentException("File size exceeds maximum allowed size of " + (MAX_FILE_SIZE / 1024 / 1024) + "MB");
+        }
+        
+        // Validate file extension
+        String originalFileName = file.getOriginalFilename();
+        if (originalFileName == null || !isValidFileExtension(originalFileName)) {
+            throw new IllegalArgumentException("File type not allowed. Allowed types: PDF, Images, Documents, Videos, Audio");
+        }
+        
+        // Validate content type
+        String contentType = file.getContentType();
+        if (contentType == null || !isValidContentType(contentType)) {
+            throw new IllegalArgumentException("File content type not allowed");
+        }
+    }
+    
+    private boolean isValidFileExtension(String fileName) {
+        String extension = getFileExtension(fileName).toLowerCase();
+        for (String allowedExtension : ALLOWED_EXTENSIONS) {
+            if (extension.equals(allowedExtension)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    private boolean isValidContentType(String contentType) {
+        for (String allowedType : ALLOWED_CONTENT_TYPES) {
+            if (contentType.equals(allowedType)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    private String getFileExtension(String fileName) {
+        int lastDotIndex = fileName.lastIndexOf('.');
+        return lastDotIndex > 0 ? fileName.substring(lastDotIndex) : "";
+    }
+    
+    private com.example.kidic.entity.MedicalRecord.FileType getFileTypeFromContentType(String contentType) {
+        if (contentType.startsWith("image/")) {
+            return com.example.kidic.entity.MedicalRecord.FileType.IMAGE;
+        } else if (contentType.equals("application/pdf")) {
+            return com.example.kidic.entity.MedicalRecord.FileType.PDF;
+        } else if (contentType.startsWith("video/")) {
+            return com.example.kidic.entity.MedicalRecord.FileType.VIDEO;
+        } else if (contentType.startsWith("audio/")) {
+            return com.example.kidic.entity.MedicalRecord.FileType.AUDIO;
+        } else if (contentType.contains("document") || contentType.contains("word") || contentType.equals("text/plain")) {
+            return com.example.kidic.entity.MedicalRecord.FileType.DOCUMENT;
+        } else {
+            return com.example.kidic.entity.MedicalRecord.FileType.OTHER;
+        }
+    }
+    
+    /**
+     * Result class for file processing operations
+     */
+    public static class FileStorageResult {
+        private final String originalFileName;
+        private final byte[] fileContent;
+        private final long fileSize;
+        private final String contentType;
+        private final com.example.kidic.entity.MedicalRecord.FileType fileType;
+        
+        public FileStorageResult(String originalFileName, byte[] fileContent,
+                               long fileSize, String contentType, com.example.kidic.entity.MedicalRecord.FileType fileType) {
+            this.originalFileName = originalFileName;
+            this.fileContent = fileContent;
+            this.fileSize = fileSize;
+            this.contentType = contentType;
+            this.fileType = fileType;
+        }
+        
+        public String getOriginalFileName() {
+            return originalFileName;
+        }
+        
+        public byte[] getFileContent() {
+            return fileContent;
+        }
+        
+        public long getFileSize() {
+            return fileSize;
+        }
+        
+        public String getContentType() {
+            return contentType;
+        }
+        
+        public com.example.kidic.entity.MedicalRecord.FileType getFileType() {
+            return fileType;
+        }
+    }
+}

--- a/kidic/src/main/java/com/example/kidic/service/GrowthRecordService.java
+++ b/kidic/src/main/java/com/example/kidic/service/GrowthRecordService.java
@@ -1,0 +1,73 @@
+package com.example.kidic.service;
+
+import com.example.kidic.entity.Child;
+import com.example.kidic.entity.GrowthRecord;
+import com.example.kidic.repository.ChildRepository;
+import com.example.kidic.repository.GrowthRecordRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@Transactional
+public class GrowthRecordService {
+
+    @Autowired
+    private GrowthRecordRepository growthRecordRepository;
+
+    @Autowired
+    private ChildRepository childRepository;
+
+    public List<GrowthRecord> listForChild(Long childId) {
+        return growthRecordRepository.findByChildId(childId);
+    }
+
+    public GrowthRecord addForChild(Long childId,
+                                    String additionalInfo,
+                                    LocalDate dateOfRecord,
+                                    Double height,
+                                    Double weight,
+                                    GrowthRecord.GrowthType type,
+                                    GrowthRecord.StatusType status) {
+        Child child = childRepository.findById(childId)
+                .orElseThrow(() -> new IllegalArgumentException("Child not found"));
+        GrowthRecord record = new GrowthRecord(additionalInfo, dateOfRecord, height, weight, type, status, child);
+        return growthRecordRepository.save(record);
+    }
+
+    public GrowthRecord editForChild(Long childId,
+                                     Long recordId,
+                                     String additionalInfo,
+                                     LocalDate dateOfRecord,
+                                     Double height,
+                                     Double weight,
+                                     GrowthRecord.GrowthType type,
+                                     GrowthRecord.StatusType status) {
+        GrowthRecord record = growthRecordRepository.findById(recordId)
+                .orElseThrow(() -> new IllegalArgumentException("Growth record not found"));
+        if (!record.getChild().getId().equals(childId)) {
+            throw new IllegalArgumentException("Record does not belong to child");
+        }
+        if (additionalInfo != null) record.setAdditionalInfo(additionalInfo);
+        if (dateOfRecord != null) record.setDateOfRecord(dateOfRecord);
+        if (height != null) record.setHeight(height);
+        if (weight != null) record.setWeight(weight);
+        if (type != null) record.setType(type);
+        if (status != null) record.setStatus(status);
+        return growthRecordRepository.save(record);
+    }
+
+    public void deleteForChild(Long childId, Long recordId) {
+        GrowthRecord record = growthRecordRepository.findById(recordId)
+                .orElseThrow(() -> new IllegalArgumentException("Growth record not found"));
+        if (!record.getChild().getId().equals(childId)) {
+            throw new IllegalArgumentException("Record does not belong to child");
+        }
+        growthRecordRepository.delete(record);
+    }
+}
+
+

--- a/kidic/src/main/java/com/example/kidic/service/MedicalRecordService.java
+++ b/kidic/src/main/java/com/example/kidic/service/MedicalRecordService.java
@@ -1,0 +1,243 @@
+package com.example.kidic.service;
+
+import com.example.kidic.config.JwtService;
+import com.example.kidic.dto.MedicalRecordRequestDTO;
+import com.example.kidic.dto.MedicalRecordResponseDTO;
+import com.example.kidic.dto.MedicalRecordWithFileRequestDTO;
+import com.example.kidic.entity.Child;
+import com.example.kidic.entity.MedicalRecord;
+import com.example.kidic.repository.ChildRepository;
+import com.example.kidic.repository.MedicalRecordRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+public class MedicalRecordService {
+    
+    @Autowired
+    private MedicalRecordRepository medicalRecordRepository;
+    
+    @Autowired
+    private ChildRepository childRepository;
+    
+    @Autowired
+    private JwtService jwtService;
+    
+    @Autowired
+    private FileStorageService fileStorageService;
+    
+    /**
+     * Add a new medical record for a specific child
+     */
+    public MedicalRecordResponseDTO addMedicalRecord(Long childId, MedicalRecordRequestDTO request, String token) {
+        // Validate that the child belongs to the family of the authenticated user
+        Child child = validateChildAccess(childId, token);
+        
+        MedicalRecord medicalRecord = new MedicalRecord();
+        medicalRecord.setType(request.getType());
+        medicalRecord.setDateOfRecord(request.getDateOfRecord());
+        medicalRecord.setDescription(request.getDescription());
+        medicalRecord.setFileType(request.getFile());
+        medicalRecord.setStatus(request.getStatus() != null ? request.getStatus() : MedicalRecord.StatusType.ACTIVE);
+        medicalRecord.setChild(child);
+        
+        MedicalRecord savedRecord = medicalRecordRepository.save(medicalRecord);
+        return toResponseDTO(savedRecord);
+    }
+    
+    /**
+     * Edit an existing medical record
+     */
+    public MedicalRecordResponseDTO editMedicalRecord(Long childId, Long recordId, MedicalRecordRequestDTO request, String token) {
+        // Validate that the child belongs to the family of the authenticated user
+        validateChildAccess(childId, token);
+        
+        MedicalRecord medicalRecord = medicalRecordRepository.findById(recordId)
+                .orElseThrow(() -> new IllegalArgumentException("Medical record not found"));
+        
+        // Validate that the record belongs to the specified child
+        if (!medicalRecord.getChild().getId().equals(childId)) {
+            throw new IllegalArgumentException("Medical record does not belong to the specified child");
+        }
+        
+        // Update the record
+        medicalRecord.setType(request.getType());
+        medicalRecord.setDateOfRecord(request.getDateOfRecord());
+        medicalRecord.setDescription(request.getDescription());
+        medicalRecord.setFileType(request.getFile());
+        if (request.getStatus() != null) {
+            medicalRecord.setStatus(request.getStatus());
+        }
+        
+        MedicalRecord updatedRecord = medicalRecordRepository.save(medicalRecord);
+        return toResponseDTO(updatedRecord);
+    }
+    
+    /**
+     * Add a new medical record with file upload for a specific child
+     */
+    public MedicalRecordResponseDTO addMedicalRecordWithFile(Long childId, MedicalRecordWithFileRequestDTO request, String token) throws IOException {
+        // Validate that the child belongs to the family of the authenticated user
+        Child child = validateChildAccess(childId, token);
+        
+        MedicalRecord medicalRecord = new MedicalRecord();
+        medicalRecord.setType(request.getType());
+        medicalRecord.setDateOfRecord(request.getDateOfRecord());
+        medicalRecord.setDescription(request.getDescription());
+        medicalRecord.setStatus(request.getStatus() != null ? request.getStatus() : MedicalRecord.StatusType.ACTIVE);
+        medicalRecord.setChild(child);
+        
+        // Handle file upload if file is provided
+        if (request.getFile() != null && !request.getFile().isEmpty()) {
+            FileStorageService.FileStorageResult fileResult = fileStorageService.processFileForDatabase(request.getFile());
+            medicalRecord.setFileType(fileResult.getFileType());
+            medicalRecord.setFileName(fileResult.getOriginalFileName());
+            medicalRecord.setFileContent(fileResult.getFileContent());
+            medicalRecord.setFileSize(fileResult.getFileSize());
+            medicalRecord.setFileContentType(fileResult.getContentType());
+        }
+        
+        MedicalRecord savedRecord = medicalRecordRepository.save(medicalRecord);
+        return toResponseDTO(savedRecord);
+    }
+    
+    /**
+     * Edit an existing medical record with optional file upload
+     */
+    public MedicalRecordResponseDTO editMedicalRecordWithFile(Long childId, Long recordId, MedicalRecordWithFileRequestDTO request, String token) throws IOException {
+        // Validate that the child belongs to the family of the authenticated user
+        validateChildAccess(childId, token);
+        
+        MedicalRecord medicalRecord = medicalRecordRepository.findById(recordId)
+                .orElseThrow(() -> new IllegalArgumentException("Medical record not found"));
+        
+        // Validate that the record belongs to the specified child
+        if (!medicalRecord.getChild().getId().equals(childId)) {
+            throw new IllegalArgumentException("Medical record does not belong to the specified child");
+        }
+        
+        // Update the record
+        medicalRecord.setType(request.getType());
+        medicalRecord.setDateOfRecord(request.getDateOfRecord());
+        medicalRecord.setDescription(request.getDescription());
+        if (request.getStatus() != null) {
+            medicalRecord.setStatus(request.getStatus());
+        }
+        
+        // Handle file upload if new file is provided
+        if (request.getFile() != null && !request.getFile().isEmpty()) {
+            // Process new file for database storage
+            FileStorageService.FileStorageResult fileResult = fileStorageService.processFileForDatabase(request.getFile());
+            medicalRecord.setFileType(fileResult.getFileType());
+            medicalRecord.setFileName(fileResult.getOriginalFileName());
+            medicalRecord.setFileContent(fileResult.getFileContent());
+            medicalRecord.setFileSize(fileResult.getFileSize());
+            medicalRecord.setFileContentType(fileResult.getContentType());
+        }
+        
+        MedicalRecord updatedRecord = medicalRecordRepository.save(medicalRecord);
+        return toResponseDTO(updatedRecord);
+    }
+    
+    /**
+     * Delete a medical record
+     */
+    public void deleteMedicalRecord(Long childId, Long recordId, String token) {
+        // Validate that the child belongs to the family of the authenticated user
+        validateChildAccess(childId, token);
+        
+        MedicalRecord medicalRecord = medicalRecordRepository.findById(recordId)
+                .orElseThrow(() -> new IllegalArgumentException("Medical record not found"));
+        
+        // Validate that the record belongs to the specified child
+        if (!medicalRecord.getChild().getId().equals(childId)) {
+            throw new IllegalArgumentException("Medical record does not belong to the specified child");
+        }
+        
+        // File content will be automatically deleted when the record is deleted from database
+        
+        medicalRecordRepository.delete(medicalRecord);
+    }
+    
+    /**
+     * Get all medical records for a specific child
+     */
+    public List<MedicalRecordResponseDTO> getMedicalRecordsForChild(Long childId, String token) {
+        // Validate that the child belongs to the family of the authenticated user
+        Child child = validateChildAccess(childId, token);
+        
+        List<MedicalRecord> records = medicalRecordRepository.findByChild(child);
+        return records.stream()
+                .map(this::toResponseDTO)
+                .collect(Collectors.toList());
+    }
+    
+    /**
+     * Get a specific medical record
+     */
+    public MedicalRecordResponseDTO getMedicalRecord(Long childId, Long recordId, String token) {
+        // Validate that the child belongs to the family of the authenticated user
+        validateChildAccess(childId, token);
+        
+        MedicalRecord medicalRecord = medicalRecordRepository.findById(recordId)
+                .orElseThrow(() -> new IllegalArgumentException("Medical record not found"));
+        
+        // Validate that the record belongs to the specified child
+        if (!medicalRecord.getChild().getId().equals(childId)) {
+            throw new IllegalArgumentException("Medical record does not belong to the specified child");
+        }
+        
+        return toResponseDTO(medicalRecord);
+    }
+    
+    /**
+     * Validate that the child belongs to the family of the authenticated user
+     */
+    private Child validateChildAccess(Long childId, String token) {
+        UUID familyId = jwtService.extractFamilyId(token);
+        
+        if (familyId == null) {
+            throw new IllegalArgumentException("User does not belong to any family");
+        }
+        
+        Child child = childRepository.findById(childId)
+                .orElseThrow(() -> new IllegalArgumentException("Child not found"));
+        
+        if (!child.getFamily().getId().equals(familyId)) {
+            throw new IllegalArgumentException("Child does not belong to your family");
+        }
+        
+        return child;
+    }
+    
+    /**
+     * Convert MedicalRecord entity to MedicalRecordResponseDTO
+     */
+    private MedicalRecordResponseDTO toResponseDTO(MedicalRecord medicalRecord) {
+        MedicalRecordResponseDTO dto = MedicalRecordResponseDTO.builder()
+                .id(medicalRecord.getId())
+                .type(medicalRecord.getType())
+                .dateOfRecord(medicalRecord.getDateOfRecord())
+                .description(medicalRecord.getDescription())
+                .fileType(medicalRecord.getFileType())
+                .fileName(medicalRecord.getFileName())
+                .fileSize(medicalRecord.getFileSize())
+                .fileContentType(medicalRecord.getFileContentType())
+                .status(medicalRecord.getStatus())
+                .childId(medicalRecord.getChild().getId())
+                .childName(medicalRecord.getChild().getName())
+                .build();
+        
+        // Manually set file content since Lombok builder might not handle byte[] properly
+        dto.setFileContent(medicalRecord.getFileContent());
+        
+        return dto;
+    }
+}

--- a/kidic/src/main/java/com/example/kidic/service/ProductService.java
+++ b/kidic/src/main/java/com/example/kidic/service/ProductService.java
@@ -1,0 +1,114 @@
+package com.example.kidic.service;
+
+import com.example.kidic.entity.Product;
+import com.example.kidic.repository.ProductRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+@Transactional
+public class ProductService {
+    
+    @Autowired
+    private ProductRepository productRepository;
+    
+    @Autowired
+    private FileStorageService fileStorageService;
+    
+    /**
+     * Create a new product (without file upload)
+     */
+    public Product createProduct(String name,
+                                 String link,
+                                 String description,
+                                 Product.ImageType imageType,
+                                 Product.CategoryType category) {
+        Product product = new Product(name, link, description, imageType, category);
+        return productRepository.save(product);
+    }
+    
+    /**
+     * Update an existing product (without file upload)
+     */
+    public Product updateProduct(Long productId,
+                                 String name,
+                                 String link,
+                                 String description,
+                                 Product.ImageType imageType,
+                                 Product.CategoryType category) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("Product not found"));
+        if (name != null) product.setName(name);
+        if (link != null) product.setLink(link);
+        if (description != null) product.setDescription(description);
+        if (imageType != null) product.setImageType(imageType);
+        if (category != null) product.setCategory(category);
+        return productRepository.save(product);
+    }
+    
+    /**
+     * Delete a product
+     */
+    public void deleteProduct(Long productId) {
+        if (!productRepository.existsById(productId)) {
+            throw new IllegalArgumentException("Product not found");
+        }
+        productRepository.deleteById(productId);
+    }
+    
+    /**
+     * List all products
+     */
+    public java.util.List<Product> listProducts() {
+        return productRepository.findAll();
+    }
+    
+    /**
+     * Upload image for a product
+     */
+    public Product uploadProductImage(Long productId, MultipartFile file) throws IOException {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("Product not found"));
+        
+        // Process file for database storage
+        FileStorageService.FileStorageResult fileResult = fileStorageService.processFileForDatabase(file);
+        
+        // Update product with file information
+        product.setImageType(Product.ImageType.CUSTOM);
+        product.setImageName(fileResult.getOriginalFileName());
+        product.setImageContent(fileResult.getFileContent());
+        product.setImageSize(fileResult.getFileSize());
+        product.setImageContentType(fileResult.getContentType());
+        
+        return productRepository.save(product);
+    }
+    
+    /**
+     * Get a product
+     */
+    public Product getProduct(Long productId) {
+        return productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("Product not found"));
+    }
+    
+    /**
+     * Delete product image
+     */
+    public Product deleteProductImage(Long productId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("Product not found"));
+        
+        // Clear file information
+        product.setImageType(Product.ImageType.IMAGE_1); // Default to first image
+        product.setImageName(null);
+        product.setImageContent(null);
+        product.setImageSize(null);
+        product.setImageContentType(null);
+        
+        return productRepository.save(product);
+    }
+}

--- a/kidic/src/main/resources/application.properties
+++ b/kidic/src/main/resources/application.properties
@@ -1,15 +1,18 @@
 spring.application.name=kidic
 
-# Database Configuration - Using environment variables
-spring.datasource.url=jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?allowPublicKeyRetrieval=true&useSSL=false&createDatabaseIfNotExist=true
-spring.datasource.username=${DB_USER}
-spring.datasource.password=${DB_PASS}
+# Import external env-style properties if present (project root)
+spring.config.import=optional:file:./environment.properties
+
+# Database Configuration - Using environment variables (with sane defaults)
+spring.datasource.url=jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:kidic_db}?allowPublicKeyRetrieval=true&useSSL=false&createDatabaseIfNotExist=true
+spring.datasource.username=${DB_USER:root}
+spring.datasource.password=${DB_PASS:}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
-# JPA / Hibernate - Drop and recreate schema to fix foreign key issues
-spring.jpa.hibernate.ddl-auto=create-drop
+# JPA / Hibernate - Keep schema and update incrementally so data persists
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
 
 # Disable data.sql execution since file is empty
@@ -22,4 +25,9 @@ spring.flyway.enabled=false
 #jwt.secret=${JWT_SECRET:JWTSecretKeyForMeatHomeAppSecureEnoughForHS256Algorithm}
 #jwt.expirationMs=${JWT_EXPIRATION_MS:3600000}
 #jwt.expirationMsLong=${JWT_EXPIRATION_MS_LONG:604800000}
+
+# File Upload Configuration
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB
+spring.servlet.multipart.enabled=true
 


### PR DESCRIPTION
This pull request introduces comprehensive improvements to the Kidic backend project, focusing on developer onboarding, API documentation, configuration management, and testability. The most significant changes include a rewritten and expanded `README.md` with detailed API documentation, the addition of a Postman collection for easy API testing, a new environment configuration file, and updates to both data initialization and security configuration for improved reliability and clarity.

**Documentation & Developer Experience**
* Completely rewrote and expanded `README.md` to provide detailed API documentation, including endpoints, request/response formats, authentication, error handling, and usage notes. This makes onboarding and API usage much easier for developers.
* Added `Kidic.postman_collection.json` to the `postman` directory, allowing developers to quickly test all major API endpoints (Products, Medical Records, Growth Records, Test APIs) using Postman.

**Configuration & Environment**
* Introduced `environment.properties` to centralize configuration for database, JWT, and server settings, improving clarity and simplifying environment setup.

**Backend Initialization & Security**
* Refactored `DataInitializer.java` to let JPA generate family IDs automatically, preventing optimistic locking issues, and clarified parent/family persistence logic.
* Updated security configuration to explicitly allow public access to `/api/auth/**`, `/api/test/**`, and `/actuator/**` endpoints, matching the documentation and improving developer/test experience.